### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "torch",
     "torchvision",
     "transformers[sentencepiece]<=4.49.0",
-    "timm>=1.0.15,<1.0.19",
+    "timm==1.0.15",
     "einops",
     "accelerate",
     "pillow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "torch",
     "torchvision",
     "transformers[sentencepiece]<=4.49.0",
-    "timm>=1.0.15",
+    "timm>=1.0.15,<1.0.19",
     "einops",
     "accelerate",
     "pillow",


### PR DESCRIPTION
Fix compatibility issue with timm>=1.0.15

🔧 Problem
When using timm versions >1.0.15, the following error occurs:

TypeError: Block_w_KVCache.__init__() got an unexpected keyword argument 'scale_attn_norm'
css